### PR TITLE
update to use composeWithDevTools in store.js

### DIFF
--- a/client/src/store.js
+++ b/client/src/store.js
@@ -1,7 +1,8 @@
-import { createStore, applyMiddleware, compose } from "redux";
+import { createStore, applyMiddleware } from "redux";
 import thunk from "redux-thunk";
 import rootReducer from "./reducers";
 import { initialChorelistState } from "./reducers/chorelistReducer";
+import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
 
 const initialState = {
     chorelist: initialChorelistState
@@ -11,9 +12,8 @@ const middleware = [thunk];
 const store = createStore(
     rootReducer,
     initialState,
-    compose(
-        applyMiddleware(...middleware),
-        window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+    composeWithDevTools(
+        applyMiddleware(...middleware)
     )
 );
 
@@ -23,3 +23,6 @@ export default store;
 // NOTES
 // createStore() creates a Redux store that holds the complete state tree of your app. There should only be a single store in your app.
 // Our store also sends application state to our React components, which will react accordingly to that state.
+// To allow the app to work in incognito mode, transitioned from using 'compose' to 'composeWithDevTools'. Refer to:
+// https://www.npmjs.com/package/redux-devtools-extension
+// https://github.com/reduxjs/redux/issues/2359

--- a/package-lock.json
+++ b/package-lock.json
@@ -1741,6 +1741,11 @@
         "picomatch": "^2.2.1"
       }
     },
+    "redux-devtools-extension": {
+      "version": "2.13.8",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
+      "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
+    },
     "regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "morgan": "^1.10.0",
     "passport": "^0.4.1",
     "passport-jwt": "^4.0.0",
+    "redux-devtools-extension": "^2.13.8",
     "validator": "^13.1.17"
   },
   "devDependencies": {


### PR DESCRIPTION
To allow the app to work in incognito mode, transitioned from using 'compose' to 'composeWithDevTools' in store.js. 
You will need to run "npm install" to verify the change.

Refer to:
https://www.npmjs.com/package/redux-devtools-extension
https://github.com/reduxjs/redux/issues/2359